### PR TITLE
Remove card view and add read-only work order viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import {
 import { loadLocal, saveLocal } from "./utils";
 import WorkOrderForm from "./components/WorkOrderForm";
 import WorkOrderTable from "./components/WorkOrderTable";
-import WorkOrderCard from "./components/WorkOrderCard";
 import ExportButton from "./components/ExportButton";
 
 export default function App() {
@@ -31,7 +30,7 @@ export default function App() {
   const [statusFilter, setStatusFilter] = useState<Status | "All">("All");
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<WorkOrder | null>(null);
-  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+  const [viewing, setViewing] = useState<WorkOrder | null>(null);
   const [apiOk, setApiOk] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -227,12 +226,6 @@ export default function App() {
               ))}
             </select>
             <button
-              onClick={() => setViewMode(viewMode === 'cards' ? 'table' : 'cards')}
-              className="px-3 py-2 rounded-xl bg-slate-800 hover:bg-slate-700"
-            >
-              {viewMode === 'cards' ? 'Table View' : 'Card View'}
-            </button>
-            <button
               onClick={() => setShowForm((s) => !s)}
               className="px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 transition font-medium"
             >
@@ -263,33 +256,19 @@ export default function App() {
             />
           </div>
         )}
-
-        {viewMode === 'cards' ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {filtered.map((o) => (
-              <WorkOrderCard
-                key={o.id}
-                order={o}
-                onUpdate={onUpdate}
-                onDelete={onDelete}
-                onEdit={(ord) => setEditing(ord)}
-              />
-            ))}
-            {filtered.length === 0 && (
-              <div className="text-slate-400">No work orders found. Create one to get started.</div>
-            )}
+        {viewing && (
+          <div className="mb-6">
+            <WorkOrderForm initial={viewing} readOnly onSubmit={() => {}} onCancel={() => setViewing(null)} />
           </div>
-        ) : (
-          <WorkOrderTable
-            orders={filtered}
-            onUpdate={onUpdate}
-            onDelete={onDelete}
-            onOpen={(id) => {
-              setViewMode('cards');
-            }}
-            onEdit={(o) => setEditing(o)}
-          />
         )}
+
+        <WorkOrderTable
+          orders={filtered}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          onOpen={(o) => setViewing(o)}
+          onEdit={(o) => setEditing(o)}
+        />
       </main>
     </div>
   );

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 
-export default function Chip({ children, onRemove }: { children: React.ReactNode; onRemove: () => void }) {
+export default function Chip({
+  children,
+  onRemove,
+}: {
+  children: React.ReactNode;
+  onRemove?: () => void;
+}) {
   return (
     <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-slate-800 border border-slate-700">
       {children}
-      <button
-        onClick={onRemove}
-        className="ml-1 inline-flex items-center justify-center w-4 h-4 rounded-full bg-slate-700 hover:bg-slate-600"
-        title="Remove"
-      >
-        ×
-      </button>
+      {onRemove && (
+        <button
+          onClick={onRemove}
+          className="ml-1 inline-flex items-center justify-center w-4 h-4 rounded-full bg-slate-700 hover:bg-slate-600"
+          title="Remove"
+        >
+          ×
+        </button>
+      )}
     </span>
   );
 }

--- a/src/components/DateField.tsx
+++ b/src/components/DateField.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function DateField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+export default function DateField({ label, value, onChange, disabled }: { label: string; value: string; onChange: (v: string) => void; disabled?: boolean }) {
   return (
     <div>
       <label className="block text-sm text-slate-300 mb-1">{label}</label>
@@ -8,7 +8,8 @@ export default function DateField({ label, value, onChange }: { label: string; v
         type="date"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full"
+        disabled={disabled}
+        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full disabled:opacity-50"
       />
     </div>
   );

--- a/src/components/NumberField.tsx
+++ b/src/components/NumberField.tsx
@@ -5,11 +5,13 @@ export default function NumberField({
   value,
   onChange,
   min,
+  disabled,
 }: {
   label: string;
   value: number;
   onChange: (v: number) => void;
   min?: number;
+  disabled?: boolean;
 }) {
   return (
     <div>
@@ -19,7 +21,8 @@ export default function NumberField({
         value={value}
         min={min}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full"
+        disabled={disabled}
+        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full disabled:opacity-50"
       />
     </div>
   );

--- a/src/components/SelectField.tsx
+++ b/src/components/SelectField.tsx
@@ -5,11 +5,13 @@ export default function SelectField({
   value,
   onChange,
   options,
+  disabled,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   options: readonly string[];
+  disabled?: boolean;
 }) {
   return (
     <div>
@@ -17,7 +19,8 @@ export default function SelectField({
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full"
+        disabled={disabled}
+        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full disabled:opacity-50"
       >
         {options.map((opt) => (
           <option key={opt} value={opt}>

--- a/src/components/TextAreaField.tsx
+++ b/src/components/TextAreaField.tsx
@@ -5,11 +5,13 @@ export default function TextAreaField({
   value,
   onChange,
   rows = 3,
+  disabled,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   rows?: number;
+  disabled?: boolean;
 }) {
   return (
     <div>
@@ -18,7 +20,8 @@ export default function TextAreaField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         rows={rows}
-        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full"
+        disabled={disabled}
+        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full disabled:opacity-50"
       />
     </div>
   );

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -6,12 +6,14 @@ export default function TextField({
   onChange,
   placeholder,
   required,
+  disabled,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
   required?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <div>
@@ -22,7 +24,8 @@ export default function TextField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full outline-none focus:ring-2 focus:ring-indigo-500"
+        disabled={disabled}
+        className="px-3 py-2 rounded-xl bg-slate-950 border border-slate-700 w-full outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
       />
     </div>
   );

--- a/src/components/WorkOrderForm.tsx
+++ b/src/components/WorkOrderForm.tsx
@@ -26,9 +26,10 @@ type Props = {
   initial?: WorkOrder;
   onSubmit: (o: WorkOrder) => void;
   onCancel: () => void;
+  readOnly?: boolean;
 };
 
-export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
+export default function WorkOrderForm({ initial, onSubmit, onCancel, readOnly = false }: Props) {
   const [summary, setSummary] = useState({
     jobNumber: initial?.jobNumber || "",
     system: initial?.system || SYSTEMS[0],
@@ -45,7 +46,7 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
   const [items, setItems] = useState<WorkOrderItem[]>(initial?.items || []);
 
   useEffect(() => {
-    if (!initial) addItem();
+    if (!initial && !readOnly) addItem();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -137,17 +138,17 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
       <h2 className="text-xl font-semibold mb-4">Work Order</h2>
       <div className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <TextField label="Job Number" value={summary.jobNumber} onChange={(v) => setSummary((s) => ({ ...s, jobNumber: v }))} required />
-          <TextField label="Job Name" value={summary.jobName} onChange={(v) => setSummary((s) => ({ ...s, jobName: v }))} required />
-          <TextField label="Project Manager" value={summary.jobPM} onChange={(v) => setSummary((s) => ({ ...s, jobPM: v }))} required />
-          <TextField label="Job Address" value={summary.jobAddress} onChange={(v) => setSummary((s) => ({ ...s, jobAddress: v }))} />
-          <TextField label="Superintendent" value={summary.jobSuperintendent} onChange={(v) => setSummary((s) => ({ ...s, jobSuperintendent: v }))} />
-          <SelectField label="System" value={summary.system} options={SYSTEMS} onChange={(v) => setSummary((s) => ({ ...s, system: v as System }))} />
-          <DateField label="Date Issued" value={summary.dateIssued} onChange={(v) => setSummary((s) => ({ ...s, dateIssued: v }))} />
-          <DateField label="Material Delivery" value={summary.materialDeliveryDate} onChange={(v) => setSummary((s) => ({ ...s, materialDeliveryDate: v }))} />
-          <DateField label="Completion Date" value={summary.completionDate} onChange={(v) => setSummary((s) => ({ ...s, completionDate: v }))} />
+          <TextField label="Job Number" value={summary.jobNumber} onChange={(v) => setSummary((s) => ({ ...s, jobNumber: v }))} required disabled={readOnly} />
+          <TextField label="Job Name" value={summary.jobName} onChange={(v) => setSummary((s) => ({ ...s, jobName: v }))} required disabled={readOnly} />
+          <TextField label="Project Manager" value={summary.jobPM} onChange={(v) => setSummary((s) => ({ ...s, jobPM: v }))} required disabled={readOnly} />
+          <TextField label="Job Address" value={summary.jobAddress} onChange={(v) => setSummary((s) => ({ ...s, jobAddress: v }))} disabled={readOnly} />
+          <TextField label="Superintendent" value={summary.jobSuperintendent} onChange={(v) => setSummary((s) => ({ ...s, jobSuperintendent: v }))} disabled={readOnly} />
+          <SelectField label="System" value={summary.system} options={SYSTEMS} onChange={(v) => setSummary((s) => ({ ...s, system: v as System }))} disabled={readOnly} />
+          <DateField label="Date Issued" value={summary.dateIssued} onChange={(v) => setSummary((s) => ({ ...s, dateIssued: v }))} disabled={readOnly} />
+          <DateField label="Material Delivery" value={summary.materialDeliveryDate} onChange={(v) => setSummary((s) => ({ ...s, materialDeliveryDate: v }))} disabled={readOnly} />
+          <DateField label="Completion Date" value={summary.completionDate} onChange={(v) => setSummary((s) => ({ ...s, completionDate: v }))} disabled={readOnly} />
           <div className="md:col-span-2">
-            <TextAreaField label="Notes" value={summary.notes} onChange={(v) => setSummary((s) => ({ ...s, notes: v }))} />
+            <TextAreaField label="Notes" value={summary.notes} onChange={(v) => setSummary((s) => ({ ...s, notes: v }))} disabled={readOnly} />
           </div>
         </div>
 
@@ -155,10 +156,10 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
           {items.map((it) => (
             <div key={it.id} className="rounded-xl border border-slate-800 p-4">
               <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
-                <SelectField label="Scope" value={it.scope} options={SCOPES} onChange={(v) => updateItem(it.id, { scope: v as Scope })} />
-                <SelectField label="Item Type" value={it.type} options={ITEM_TYPES} onChange={(v) => updateItem(it.id, { type: v as ItemType })} />
-                <TextField label="Elevation" value={it.elevation} onChange={(v) => updateItem(it.id, { elevation: v })} />
-                <NumberField label="Quantity" value={it.quantity} min={0} onChange={(v) => updateItem(it.id, { quantity: v })} />
+                <SelectField label="Scope" value={it.scope} options={SCOPES} onChange={(v) => updateItem(it.id, { scope: v as Scope })} disabled={readOnly} />
+                <SelectField label="Item Type" value={it.type} options={ITEM_TYPES} onChange={(v) => updateItem(it.id, { type: v as ItemType })} disabled={readOnly} />
+                <TextField label="Elevation" value={it.elevation} onChange={(v) => updateItem(it.id, { elevation: v })} disabled={readOnly} />
+                <NumberField label="Quantity" value={it.quantity} min={0} onChange={(v) => updateItem(it.id, { quantity: v })} disabled={readOnly} />
                 <SelectField
                   label="Status"
                   value={it.status}
@@ -169,6 +170,7 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
                       holdReason: v === "On Hold" ? it.holdReason || HOLD_REASONS[0] : "",
                     })
                   }
+                  disabled={readOnly}
                 />
               </div>
               {it.status === "On Hold" && (
@@ -178,37 +180,43 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
                     value={it.holdReason || HOLD_REASONS[0]}
                     options={HOLD_REASONS}
                     onChange={(v) => updateItem(it.id, { holdReason: v as HoldReason })}
+                    disabled={readOnly}
                   />
                 </div>
               )}
               {/* Per-item completion dates (multiple) */}
               <div className="mt-3">
                 <label className="block text-sm text-slate-300 mb-1">Completion Dates</label>
-                <input
-                  type="date"
-                  className="px-3 py-2 rounded-xl bg-slate-900 border border-slate-700 w-full"
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    if (val.length === 10) {
-                      updateItem(it.id, {
-                        completionDates: Array.from(
-                          new Set([...(it.completionDates || []), val])
-                        ),
-                      });
-                      e.target.value = "";
-                    }
-                  }}
-                />
+                {!readOnly && (
+                  <input
+                    type="date"
+                    className="px-3 py-2 rounded-xl bg-slate-900 border border-slate-700 w-full"
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (val.length === 10) {
+                        updateItem(it.id, {
+                          completionDates: Array.from(
+                            new Set([...(it.completionDates || []), val])
+                          ),
+                        });
+                        e.target.value = "";
+                      }
+                    }}
+                  />
+                )}
                 <div className="flex flex-wrap gap-2 mt-2">
                   {(it.completionDates || []).map((d) => (
                     <Chip
                       key={d}
-                      onRemove={() =>
-                        updateItem(it.id, {
-                          completionDates: (it.completionDates || []).filter(
-                            (x) => x !== d
-                          ),
-                        })
+                      onRemove={
+                        readOnly
+                          ? undefined
+                          : () =>
+                              updateItem(it.id, {
+                                completionDates: (it.completionDates || []).filter(
+                                  (x) => x !== d
+                                ),
+                              })
                       }
                     >
                       {d}
@@ -216,42 +224,48 @@ export default function WorkOrderForm({ initial, onSubmit, onCancel }: Props) {
                   ))}
                 </div>
               </div>
-              <div className="mt-2 text-right">
-                <button
-                  onClick={() => removeItem(it.id)}
-                  className="text-sm px-3 py-1.5 rounded-lg bg-rose-600 hover:bg-rose-500"
-                >
-                  Remove Item
-                </button>
-              </div>
+              {!readOnly && (
+                <div className="mt-2 text-right">
+                  <button
+                    onClick={() => removeItem(it.id)}
+                    className="text-sm px-3 py-1.5 rounded-lg bg-rose-600 hover:bg-rose-500"
+                  >
+                    Remove Item
+                  </button>
+                </div>
+              )}
             </div>
           ))}
         </div>
 
         <div className="mt-3 flex items-center gap-2">
-          <button
-            onClick={addItem}
-            className="px-3 py-2 rounded-xl bg-slate-800 hover:bg-slate-700"
-          >
-            + Add Item
-          </button>
-          <button
-            onClick={save}
-            disabled={!valid}
-            className={
-              "px-4 py-2 rounded-xl font-medium " +
-              (valid
-                ? "bg-indigo-600 hover:bg-indigo-500"
-                : "bg-slate-700 text-slate-400 cursor-not-allowed")
-            }
-          >
-            {initial ? "Save Changes" : "Create Work Order"}
-          </button>
+          {!readOnly && (
+            <button
+              onClick={addItem}
+              className="px-3 py-2 rounded-xl bg-slate-800 hover:bg-slate-700"
+            >
+              + Add Item
+            </button>
+          )}
+          {!readOnly && (
+            <button
+              onClick={save}
+              disabled={!valid}
+              className={
+                "px-4 py-2 rounded-xl font-medium " +
+                (valid
+                  ? "bg-indigo-600 hover:bg-indigo-500"
+                  : "bg-slate-700 text-slate-400 cursor-not-allowed")
+              }
+            >
+              {initial ? "Save Changes" : "Create Work Order"}
+            </button>
+          )}
           <button
             onClick={onCancel}
             className="px-3 py-2 rounded-xl bg-slate-700 hover:bg-slate-600"
           >
-            Cancel
+            {readOnly ? "Close" : "Cancel"}
           </button>
         </div>
       </div>

--- a/src/components/WorkOrderTable.tsx
+++ b/src/components/WorkOrderTable.tsx
@@ -7,7 +7,7 @@ type Props = {
   orders: WorkOrder[];
   onUpdate: (id: string, patch: Partial<WorkOrder>) => void;
   onDelete: (id: string) => void;
-  onOpen: (id: string) => void;
+  onOpen: (o: WorkOrder) => void;
   onEdit: (o: WorkOrder) => void;
 };
 
@@ -58,7 +58,7 @@ export default function WorkOrderTable({ orders, onUpdate, onDelete, onOpen, onE
               </td>
               <td className="p-2 space-x-2">
                 <button
-                  onClick={() => onOpen(o.id)}
+                  onClick={() => onOpen(o)}
                   className="px-2 py-1 rounded bg-slate-700 hover:bg-slate-600"
                 >
                   Open


### PR DESCRIPTION
## Summary
- Drop card view and always render work orders as a table
- Open button displays a read-only Work Order form
- Support disabled/read-only fields across form components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52f3cf1e08329ae3898b2da36669a