### PR TITLE
feat: add role-based workflow

### DIFF
--- a/src/components/WorkOrderTable.tsx
+++ b/src/components/WorkOrderTable.tsx
@@ -9,9 +9,11 @@ type Props = {
   onDelete: (id: string) => void;
   onOpen: (o: WorkOrder) => void;
   onEdit: (o: WorkOrder) => void;
+  editableStatuses: Status[];
+  canDelete: boolean;
 };
 
-export default function WorkOrderTable({ orders, onUpdate, onDelete, onOpen, onEdit }: Props) {
+export default function WorkOrderTable({ orders, onUpdate, onDelete, onOpen, onEdit, editableStatuses, canDelete }: Props) {
   if (orders.length === 0)
     return (
       <div className="text-slate-400">No work orders found. Create one to get started.</div>
@@ -48,6 +50,7 @@ export default function WorkOrderTable({ orders, onUpdate, onDelete, onOpen, onE
                   value={o.status}
                   onChange={(e) => onUpdate(o.id, { status: e.target.value as Status })}
                   className="px-2 py-1 rounded-lg bg-slate-950 border border-slate-700"
+                  disabled={!editableStatuses.includes(o.status)}
                 >
                   {STATUSES.map((s) => (
                     <option key={s} value={s}>
@@ -71,18 +74,22 @@ export default function WorkOrderTable({ orders, onUpdate, onDelete, onOpen, onE
                 >
                   PDF
                 </a>
-                <button
-                  onClick={() => onEdit(o)}
-                  className="px-2 py-1 rounded bg-slate-700 hover:bg-slate-600"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => onDelete(o.id)}
-                  className="px-2 py-1 rounded bg-rose-600 hover:bg-rose-500"
-                >
-                  Delete
-                </button>
+                {editableStatuses.includes(o.status) && (
+                  <button
+                    onClick={() => onEdit(o)}
+                    className="px-2 py-1 rounded bg-slate-700 hover:bg-slate-600"
+                  >
+                    Edit
+                  </button>
+                )}
+                {canDelete && (
+                  <button
+                    onClick={() => onDelete(o.id)}
+                    className="px-2 py-1 rounded bg-rose-600 hover:bg-rose-500"
+                  >
+                    Delete
+                  </button>
+                )}
               </td>
             </tr>
           ))}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 export const ITEM_TYPES = ["Door", "Storefront", "Curtainwall", "Window wall"] as const;
-export const STATUSES = ["Draft", "Issued", "In Progress", "On Hold", "Complete"] as const;
+export const STATUSES = [
+  "Draft",
+  "Submitted for Review",
+  "Released to Fab",
+  "Completed",
+] as const;
 export const ITEM_STATUSES = ["In Progress", "On Hold", "Complete"] as const;
 export const HOLD_REASONS = [
   "Material Issues",
@@ -11,12 +16,20 @@ export const HOLD_REASONS = [
 export const SYSTEMS = ["System A", "System B", "System C"] as const;
 export const SCOPES = ["Kit", "Assemble", "Hardware"] as const;
 
+export const ROLES = [
+  "Project Manager",
+  "Fab Manager",
+  "Fabricator",
+  "Manager",
+] as const;
+
 export type ItemType = typeof ITEM_TYPES[number];
 export type Status = typeof STATUSES[number];
 export type ItemStatus = typeof ITEM_STATUSES[number];
 export type HoldReason = typeof HOLD_REASONS[number];
 export type System = typeof SYSTEMS[number];
 export type Scope = typeof SCOPES[number];
+export type Role = typeof ROLES[number];
 
 export type WorkOrderItem = {
   id: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,14 +5,17 @@ export function statusColor(status: string) {
   switch (status) {
     case "Draft":
       return "bg-slate-700";
-    case "Issued":
-      return "bg-green-700";
+    case "Submitted for Review":
+      return "bg-amber-700";
+    case "Released to Fab":
+      return "bg-blue-700";
+    case "Completed":
+    case "Complete":
+      return "bg-green-900";
     case "In Progress":
       return "bg-blue-700";
     case "On Hold":
       return "bg-orange-600";
-    case "Complete":
-      return "bg-green-900";
     default:
       return "bg-slate-900";
   }


### PR DESCRIPTION
## Summary
- introduce new workflow statuses and user roles
- filter and gate actions in UI based on selected role
- extend status color helper for new workflow states

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a668c813c08329ab24decb86f42fae